### PR TITLE
Revert "added == operator and != operator"

### DIFF
--- a/Fractions/Operators.cs
+++ b/Fractions/Operators.cs
@@ -76,14 +76,5 @@
         {
             return (decimal)fraction1 >= (decimal)fraction2;
         }
-
-        static public bool operator ==(Fraction fraction1, Fraction fraction2) 
-        {
-            return (fraction1.Numerator / fraction1.Denominator) == (fraction2.Numerator / fraction2.Denominator);
-        }
-        static public bool operator !=(Fraction fraction1, Fraction fraction2) 
-        {
-            return (fraction1.Numerator / fraction1.Denominator) != (fraction2.Numerator / fraction2.Denominator);
-        }
     }
 }


### PR DESCRIPTION
Reverts yonimn2000/fractions#1

@KyleMcIndoe Your addition (#1) actually does not make sense. If you want to compare the fractions, use `f1.Equivalent(f2)` to check if the values match, use `f1.Equals(f2)` to check if the numerator is the same as the denominator, and use `f1 == f2` to check if the variables reference the same `Fraction` object.

For example:
```cs
Fraction f1 = new Fraction(2, 3);
Fraction f2 = f1;
Fraction f3 = new Fraction(2, 3);
Fraction f4 = new Fraction(4, 6);

f1 == f2; // true
f1 == f3; // false
f1.Equals(f3); // true
f1.Equals(f4); // false
f1.Equivalent(f3); // true
f1.Equivalent(f4); // true
```